### PR TITLE
remove bin2nd func which is not supported in C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,13 @@ ADD_SUBDIRECTORY(ext/CoinUtils)
 ADD_SUBDIRECTORY(ext/Osi)
 ADD_SUBDIRECTORY(Clp)
 
-ADD_EXECUTABLE(hello Clp/examples/hello.cpp)
-TARGET_LINK_LIBRARIES(hello lib_Osi lib_Clp lib_CoinUtils)
-CONFIGURE_FILE(Clp/examples/hello.mps hello.mps COPYONLY)  # input needed for hello
-
-ADD_EXECUTABLE(modify Clp/examples/modify.cpp)
-TARGET_LINK_LIBRARIES(modify lib_Clp lib_CoinUtils)
-
-ADD_EXECUTABLE(minimum Clp/examples/minimum.cpp)
-TARGET_LINK_LIBRARIES(minimum lib_Clp lib_CoinUtils)
-CONFIGURE_FILE(Clp/examples/p0033.mps p0033.mps COPYONLY)  # input needed for minimum
+#ADD_EXECUTABLE(hello Clp/examples/hello.cpp)
+#TARGET_LINK_LIBRARIES(hello lib_Osi lib_Clp lib_CoinUtils)
+#CONFIGURE_FILE(Clp/examples/hello.mps hello.mps COPYONLY)  # input needed for hello
+#
+#ADD_EXECUTABLE(modify Clp/examples/modify.cpp)
+#TARGET_LINK_LIBRARIES(modify lib_Clp lib_CoinUtils)
+#
+#ADD_EXECUTABLE(minimum Clp/examples/minimum.cpp)
+#TARGET_LINK_LIBRARIES(minimum lib_Clp lib_CoinUtils)
+#CONFIGURE_FILE(Clp/examples/p0033.mps p0033.mps COPYONLY)  # input needed for minimum

--- a/ext/CoinUtils/src/CoinHelperFunctions.hpp
+++ b/ext/CoinUtils/src/CoinHelperFunctions.hpp
@@ -253,7 +253,7 @@ CoinCopyOfArrayOrZero( const T * array , const int size)
     alternative coding if USE_MEMCPY defined*/
 #ifndef COIN_USE_RESTRICT
 template <class T> inline void
-CoinMemcpyN(register const T* from, const int size, register T* to)
+CoinMemcpyN(const T* from, const int size, T* to)
 {
 #ifndef _MSC_VER
 #ifdef USE_MEMCPY

--- a/ext/CoinUtils/src/CoinOslFactorization2.cpp
+++ b/ext/CoinUtils/src/CoinOslFactorization2.cpp
@@ -20,9 +20,9 @@
 extern int ets_count;
 extern int ets_check;
 #endif
-#define COIN_REGISTER register
+#define COIN_REGISTER
 #define COIN_REGISTER2
-#define COIN_REGISTER3 register
+#define COIN_REGISTER3
 #ifdef COIN_USE_RESTRICT
 # define COIN_RESTRICT2 __restrict
 #else

--- a/ext/CoinUtils/src/CoinPackedMatrix.cpp
+++ b/ext/CoinUtils/src/CoinPackedMatrix.cpp
@@ -1494,7 +1494,7 @@ CoinPackedMatrix::minorAppendSameOrdered(const CoinPackedMatrix& matrix)
       std::transform(matrix.index_ + matrix.start_[i],
 		matrix.index_ + (matrix.start_[i] + l),
 		index_ + (start_[i] + length_[i]),
-		std::bind2nd(std::plus<int>(), minorDim_));
+		[=](double v){return v + minorDim_;} );
       CoinMemcpyN(matrix.element_ + matrix.start_[i], l,
 		       element_ + (start_[i] + length_[i]));
       length_[i] += l;

--- a/ext/CoinUtils/src/CoinPackedVector.cpp
+++ b/ext/CoinUtils/src/CoinPackedVector.cpp
@@ -285,34 +285,34 @@ void
 CoinPackedVector::operator+=(double value) 
 {
    std::transform(elements_, elements_ + nElements_, elements_,
-		  std::bind2nd(std::plus<double>(), value) );
+		  [=](double v){return v + value;} );
 }
 
 //-----------------------------------------------------------------------------
 
 void
-CoinPackedVector::operator-=(double value) 
+CoinPackedVector::operator-=(double value)
 {
    std::transform(elements_, elements_ + nElements_, elements_,
-		  std::bind2nd(std::minus<double>(), value) );
+                  [=](double v){return v - value;}  );
 }
 
 //-----------------------------------------------------------------------------
 
 void
-CoinPackedVector::operator*=(double value) 
+CoinPackedVector::operator*=(double value)
 {
    std::transform(elements_, elements_ + nElements_, elements_,
-		  std::bind2nd(std::multiplies<double>(), value) );
+                  [=](double v){return v * value;} );
 }
 
 //-----------------------------------------------------------------------------
 
 void
-CoinPackedVector::operator/=(double value) 
+CoinPackedVector::operator/=(double value)
 {
    std::transform(elements_, elements_ + nElements_, elements_,
-		  std::bind2nd(std::divides<double>(), value) );
+                  [=](double v){return v / value;}  );
 }
 
 //#############################################################################


### PR DESCRIPTION
the register is deprecated in C++11
the std::bind2nd is deprecated in C++14

Could you check whether they are identical to the original code?